### PR TITLE
fix: bump terraform 1.6.0 → 1.10.5 (post key-rotation)

### DIFF
--- a/bake/variables.pkr.hcl
+++ b/bake/variables.pkr.hcl
@@ -25,7 +25,7 @@ variable "packer_version" {
 
 variable "terraform_version" {
   type    = string
-  default = "1.6.0"
+  default = "1.10.5"
 }
 
 variable "terragrunt_version" {


### PR DESCRIPTION
The 2026-04-28 portfolio deploy build failed at terragrunt apply with 'openpgp: key expired' on hashicorp/null, hashicorp/external, hashicorp/google, and hashicorp/google-beta provider signature checks.

HashiCorp rotated their PGP signing key in 2024. Terraform versions before ~1.7 had the OLD key bundled and stopped trusting current provider releases.

Bumping to 1.10.5 (current stable, includes the new HashiCorp signing key). After this image rebuilds, the parent portfolio deploy will succeed.