### PR TITLE
fix: raise packer provisioner timeout 5m → 15m

### DIFF
--- a/bake/build.pkr.hcl
+++ b/bake/build.pkr.hcl
@@ -9,7 +9,12 @@ packer {
 
 
 locals {
-  timeout = "5m"
+  # 15m per provisioner. The all-in-one `dev-tools.docker.ubuntu` builder runs a
+  # long chain of provisioners (gcloud, packer, terraform, terragrunt, jq, etc.)
+  # while the 3 targeted sub-builders run in parallel on the same VM. With the
+  # previous 5m timeout, the all-in-one would starve mid-provisioner and hit a
+  # `context canceled`. 15m is generous but still bounds the total build.
+  timeout = "15m"
   # Create version tags only if version is provided
   basic_tags     = var.version == "" ? ["basic"] : ["basic", "basic-${var.version}"]
   packer_tags    = var.version == "" ? ["packer"] : ["packer", "packer-${var.version}"]


### PR DESCRIPTION
The 4-builder packer run runs 3 targeted images (basic, packer, terraform) in parallel with the all-in-one (dev-tools.docker.ubuntu) on a single Cloud Build VM. The all-in-one chains many heavy provisioners — gcloud SDK, packer, terraform, terragrunt, jq, etc. — while sharing CPU/IO with the others.

With the previous 5m timeout, install-terraform.sh (or one of its peers in the all-in-one builder) starved during the parallel run and hit 'Cancelling provisioner after a timeout', failing the whole build.

15m gives enough headroom while still bounding the total runtime.