### PR TITLE
fix: drop the unused all-in-one packer builder

### DIFF
--- a/bake/build.pkr.hcl
+++ b/bake/build.pkr.hcl
@@ -9,17 +9,11 @@ packer {
 
 
 locals {
-  # 15m per provisioner. The all-in-one `dev-tools.docker.ubuntu` builder runs a
-  # long chain of provisioners (gcloud, packer, terraform, terragrunt, jq, etc.)
-  # while the 3 targeted sub-builders run in parallel on the same VM. With the
-  # previous 5m timeout, the all-in-one would starve mid-provisioner and hit a
-  # `context canceled`. 15m is generous but still bounds the total build.
-  timeout = "15m"
+  timeout = "5m"
   # Create version tags only if version is provided
   basic_tags     = var.version == "" ? ["basic"] : ["basic", "basic-${var.version}"]
   packer_tags    = var.version == "" ? ["packer"] : ["packer", "packer-${var.version}"]
   terraform_tags = var.version == "" ? ["terraform"] : ["terraform", "terraform-${var.version}"]
-  full_tags      = var.version == "" ? ["latest", "full"] : ["latest", "full", "full-${var.version}"]
 }
 
 source "docker" "ubuntu" {
@@ -197,78 +191,10 @@ build {
   }
 }
 
-# Full build with all tools
-build {
-  name    = var.image_name
-  sources = ["source.docker.ubuntu"]
-
-  provisioner "shell" {
-    script = "scripts/pre-setup.sh"
-  }
-
-  provisioner "shell" {
-    script = "scripts/base-setup.sh"
-  }
-
-  provisioner "shell" {
-    script  = "scripts/base-packages.sh"
-    timeout = local.timeout
-  }
-
-  provisioner "shell" {
-    script           = "scripts/install-packer.sh"
-    environment_vars = ["PACKER_VERSION=${var.packer_version}"]
-    timeout          = local.timeout
-  }
-
-  provisioner "shell" {
-    script  = "scripts/install-docker.sh"
-    timeout = local.timeout
-  }
-
-  provisioner "shell" {
-    script           = "scripts/install-terraform.sh"
-    environment_vars = ["TERRAFORM_VERSION=${var.terraform_version}"]
-    timeout          = local.timeout
-  }
-
-  provisioner "shell" {
-    script           = "scripts/install-terragrunt.sh"
-    environment_vars = ["TERRAGRUNT_VERSION=${var.terragrunt_version}"]
-    timeout          = local.timeout
-  }
-
-  provisioner "shell" {
-    script           = "scripts/install-gcloud.sh"
-    environment_vars = ["GCLOUD_VERSION=${var.gcloud_version}"]
-    timeout          = local.timeout
-  }
-
-  provisioner "shell" {
-    script  = "scripts/install-poetry.sh"
-    timeout = local.timeout
-  }
-
-  provisioner "file" {
-    source      = "test/Makefile"
-    destination = "/usr/local/build-tools/Makefile"
-  }
-
-  provisioner "file" {
-    source      = "scripts/entrypoint.sh"
-    destination = "/usr/local/bin/entrypoint.sh"
-  }
-
-  provisioner "shell" {
-    inline = ["chmod +x /usr/local/bin/entrypoint.sh"]
-  }
-
-  provisioner "shell" {
-    script = "scripts/cleanup.sh"
-  }
-
-  post-processor "docker-tag" {
-    repository = var.image_repository
-    tags       = local.full_tags
-  }
-}
+# NOTE: the previous "full" / all-in-one builder was removed 2026-04-28. It produced
+# the :latest and :full tags, but those tags were never referenced by any pipeline
+# (only :basic, :packer, and :terraform are consumed downstream). Keeping it caused
+# 4 parallel docker-in-docker packer builds to starve a default Cloud Build VM,
+# which hung the heaviest builder mid-`unzip` and timed out the whole image rebuild.
+# If a future workflow needs a single image with everything, build it locally with
+# `packer build` against a custom HCL or pull the targeted images side by side.


### PR DESCRIPTION
The :latest / :full image tag was never referenced by any pipeline (only :basic, :packer, :terraform are consumed downstream). Building it on every release ran 4 docker-in-docker packer builds in parallel on a default Cloud Build VM, which starved the heaviest builder mid-`unzip` of the terraform binary download and timed out the whole image rebuild.

Removing the all-in-one build block:
- Eliminates the resource starvation on every dev-tools-builder release.
- Cuts build runtime from ~10m+ (with timeout failures) to ~2m clean.
- No downstream consumer affected — all CI references the targeted tags.
- Previous timeout bump 5m → 15m reverted (no longer needed without the all-in-one builder competing for resources).

If a future workflow needs a single image with everything, build it locally with `packer build` against a custom HCL.