### PR TITLE
fix: drop the broken CI smoke test step

### DIFF
--- a/config/cloudbuild.yaml
+++ b/config/cloudbuild.yaml
@@ -33,12 +33,13 @@ steps:
     id: "build"
     waitFor: ["bump-version"]
 
-  # Run the tests for the built image
-  - name: us-central1-docker.pkg.dev/${PROJECT_ID}/docker/dev-tools-builder:packer
-    entrypoint: "make"
-    args: ["test"]
-    id: "test"
-    waitFor: ["build"]
+  # NOTE: the previous "test" step was removed 2026-04-28. It ran
+  # `docker run dev-tools-builder help` against the implicit :latest tag (i.e.,
+  # the all-in-one image which was itself removed). The smoke test also failed
+  # with a docker client/server API mismatch (alpine's current `docker` package
+  # uses API 1.52, Cloud Build's docker daemon caps at 1.41). The smoke test
+  # added no real coverage — `help` succeeding only verified the entrypoint
+  # script was callable. Run `make test` locally if you need to validate.
 
   # Deploy the docker image
   - name: us-central1-docker.pkg.dev/${PROJECT_ID}/docker/dev-tools-builder:packer
@@ -48,7 +49,7 @@ steps:
       - "make deploy NEW_VERSION=$$(cat new_version.txt)"
     secretEnv: ["GITHUB_TOKEN"]
     id: "deploy"
-    waitFor: ["test"]
+    waitFor: ["build"]
 
   # Create GitHub release
   - name: "us-central1-docker.pkg.dev/${PROJECT_ID}/docker/github-ops-builder"


### PR DESCRIPTION
The test step ran `docker run dev-tools-builder help` (Makefile target `test`), which:

1. Pulled the implicit :latest tag — that was the all-in-one image, dropped in PR #8. After that drop, no :latest is republished and the test was pulling the stale orphaned :latest from v0.0.4.
2. Hit a docker client/server API mismatch even when an image was available: alpine's current `docker` package (29.1.3, API 1.52) is too new for the Cloud Build VM's docker daemon (max API 1.41), so the in-container CLI couldn't talk to the host docker socket.

The "test" was only `help` succeeding — it validated nothing meaningful. Removing it. If real validation is needed in the future, run a script that imports each tagged image and checks expected binaries are present, ideally against `gcr.io/cloud-builders/docker` for daemon compatibility.

Deploy step now waits on `build` directly instead of `test`.