### PR TITLE
fix: bump terragrunt v0.54.12 → v0.69.13 (compat with terraform 1.10)

### DIFF
--- a/bake/variables.pkr.hcl
+++ b/bake/variables.pkr.hcl
@@ -30,7 +30,7 @@ variable "terraform_version" {
 
 variable "terragrunt_version" {
   type    = string
-  default = "v0.54.12"
+  default = "v0.69.13"
 }
 
 variable "version" {


### PR DESCRIPTION
The 2026-04-28 portfolio deploy still fails after terraform was bumped to 1.10.5. The new error is provider plugins not getting installed during `terragrunt run-all apply --terragrunt-non-interactive`:

  Initializing provider plugins...
  - Reusing previous version of hashicorp/google from the dependency lock file ... Error: Required plugins are not installed
    - registry.terraform.io/hashicorp/google: there is no package for ... cached in .terraform/providers

Notably the same lock files + flags work locally with terragrunt v0.55.1, but fail with the image's pinned v0.54.12 (early 2024). Terragrunt v0.54 predates several terraform 1.7+ init-flow changes and skips the provider install phase in some non-interactive run-all paths.

Bumping to v0.69.13 (mid-2024 stable, well-tested with terraform 1.10).