### PR TITLE
fix: deploy was silently failing all docker pushes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ build: init validate
 
 # All-in-one command to build and push
 .PHONY: deploy
-deploy: configure-docker push
+deploy: refresh push
 	@if [ "$(BUILDER_TAG)" != "latest" ]; then \
 		echo "Successfully built and pushed images:"; \
 		echo "  - $(LOCATION)-docker.pkg.dev/$(PROJECT_ID)/docker/$(BUILDER_NAME):$(BUILDER_TAG)"; \

--- a/bake/scripts/install-gcloud.sh
+++ b/bake/scripts/install-gcloud.sh
@@ -12,3 +12,7 @@ echo 'Installing Google Cloud SDK...'
 ln -sf /usr/local/gcloud/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
 ln -sf /usr/local/gcloud/google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil
 ln -sf /usr/local/gcloud/google-cloud-sdk/bin/bq /usr/local/bin/bq
+# docker-credential-gcloud is required when `gcloud auth configure-docker`
+# wires up Artifact Registry pushes via a credential helper. Without this
+# symlink it isn't on PATH and every `docker push` fails silently.
+ln -sf /usr/local/gcloud/google-cloud-sdk/bin/docker-credential-gcloud /usr/local/bin/docker-credential-gcloud


### PR DESCRIPTION
Every dev-tools-builder build since v0.0.4 (Dec 2024) reported SUCCESS but never actually published images to Artifact Registry. Two compounding bugs:

1. The Makefile's `deploy` target depended on `configure-docker`, which calls `gcloud auth configure-docker` to wire a credential helper named `docker-credential-gcloud`. That binary ships with the gcloud SDK at /usr/local/gcloud/google-cloud-sdk/bin/ but install-gcloud.sh only symlinked gcloud, gsutil, and bq into /usr/local/bin/ — so the credential helper was not on PATH. Every parallel `docker push` then failed with:

     error getting credentials - err: exec: "docker-credential-gcloud":
     executable file not found in $PATH

2. The push target backgrounds all pushes with `&` and waits with bare `wait`, which exits 0 regardless of the children's exit codes. So the deploy step prints "Successfully built and pushed images" and exits 0 even when every single push failed.

Bug 2 hid bug 1 for months. Effect: the `dev-tools-builder:terraform` tag still resolves to the v0.0.4 image (terraform 1.6.0 + terragrunt v0.54.12, December 2024), explaining why all the recent merged image fixes had no effect on the parent portfolio deploy.

Fixes:
- Makefile: switch `deploy: configure-docker push` to `deploy: refresh push`. `refresh` uses `gcloud auth print-access-token | docker login` which writes a real token into ~/.docker/config.json instead of registering a missing credential helper. Works in any container that has gcloud + docker CLI.
- install-gcloud.sh: also symlink docker-credential-gcloud so any future workflow that does call `configure-docker` won't silently break again.

Bug 2 (silent push failure) is left for a follow-up — fixing it now would mean shipping the real v0.0.5 push and ALSO the failure-propagation change in the same commit, which makes rollback messier if either is wrong. Once we see a real push succeed, we can harden the `wait` semantics.