### PR TITLE
fix: pin docker API to 1.41 on build/deploy steps

### DIFF
--- a/config/cloudbuild.yaml
+++ b/config/cloudbuild.yaml
@@ -29,6 +29,14 @@ steps:
     args:
       - "-c"
       - "make build NEW_VERSION=$$(cat new_version.txt)"
+    env:
+      # The in-image docker CLI (alpine's `apk add docker` ships 29.x → API 1.52)
+      # is newer than Cloud Build's host docker daemon (max API 1.41). Pin the
+      # client to the daemon's max API so logout/login/push don't fail with
+      # `client version 1.52 is too new`. Until alpine's docker package is
+      # pinned in install-docker.sh, every Cloud Build step that calls the
+      # in-image docker CLI needs this env var.
+      - "DOCKER_API_VERSION=1.41"
     secretEnv: ["GITHUB_TOKEN"]
     id: "build"
     waitFor: ["bump-version"]
@@ -47,6 +55,8 @@ steps:
     args:
       - "-c"
       - "make deploy NEW_VERSION=$$(cat new_version.txt)"
+    env:
+      - "DOCKER_API_VERSION=1.41"
     secretEnv: ["GITHUB_TOKEN"]
     id: "deploy"
     waitFor: ["build"]


### PR DESCRIPTION
The previous "fix-deploy-push" PR switched `make deploy` from configure-docker (broken credential helper) to refresh (gcloud auth print-access-token + docker login). The auth fix was correct, but it surfaced a deeper compatibility issue that the silent push-failure had been hiding:

  Error response from daemon: client version 1.52 is too new.
  Maximum supported API version is 1.41

The dev-tools-builder:packer image installs docker via `apk add docker`, which on current alpine pulls 29.x (API 1.52). Cloud Build's host docker daemon caps at API 1.41. Every in-container `docker logout/login/push` fails the version check on startup.

Setting DOCKER_API_VERSION=1.41 on the build and deploy steps forces the docker CLI to negotiate API 1.41 with the daemon, which the daemon supports.

Long-term fix is to pin alpine's docker package in install-docker.sh (e.g. `apk add docker=20.10.~`) or migrate to gcr.io/cloud-builders/docker for any step that needs the docker CLI. For now, the env-var workaround keeps the fix minimal and reversible.

Note: only the dev-tools-builder build itself needs this. The portfolio + gcp-ovpn-portal + ansible-openvpn pipelines that consume :basic / :packer / :terraform images don't shell out to docker — they run terragrunt / packer which use direct daemon connections.